### PR TITLE
Fix issue where a css selector should have applied only to children elements of .datetimepicker-wrapper

### DIFF
--- a/datetimepicker.css
+++ b/datetimepicker.css
@@ -8,6 +8,7 @@
   width: 130px;
 }
 
-.datetimepicker-wrapper [ng-model=hours], [ng-model=minutes] {
+.datetimepicker-wrapper [ng-model=hours], 
+.datetimepicker-wrapper [ng-model=minutes] {
   width: 46px !important;
 }


### PR DESCRIPTION
Hi there,

Just proposing to fix this css selector `[ng-model=minutes]` that's most probably not scoped properly.

Cheers,

David