### PR TITLE
Ignore more files from bower package for lighter deployments

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,8 @@
     "**/.*",
     "node_modules",
     "bower_components",
+    "example.js",
+    "index.html",
     "test",
     "tests"
   ],


### PR DESCRIPTION
Assuming that the bower package is intended for prod usage, the example files should not be included.