### PR TITLE
Feature/add ability to show or hide time inputs for empty date v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Include the `ui.bootstrap.datetimepicker` module in your `app.js` file. You must
  * `date-format`
  	_(Default: 'yyyy-MM-dd')_ :
  	The format for displayed dates.
+ 	
+ * `show-time-for-empty-date`
+ _(Default: true)_ :
+ Show the time inputs even when the date is empty (null, invalid date or '') 
 
  * `datepicker-options` attribute.
   	_(Default: {})_ :

--- a/datetimepicker.js
+++ b/datetimepicker.js
@@ -30,6 +30,7 @@ angular.module('ui.bootstrap.datetimepicker',
           dayHeaderFormat: "=",
           dayTitleFormat: "=",
           monthTitleFormat: "=",
+          showTimeForEmptyDate: "=?",
           showWeeks: "=",
           startingDay: "=",
           yearRange: "=",
@@ -102,7 +103,11 @@ angular.module('ui.bootstrap.datetimepicker',
             createEvalAttr("placeholder", "placeholder") +
             "/>\n" +
             "</div>\n" +
-            "<div class=\"datetimepicker-wrapper\" ng-model=\"time\" ng-change=\"time_change()\" style=\"display:inline-block\">\n" +
+            "<div class=\"datetimepicker-wrapper\" " +
+              "ng-show=\"showTimeForEmptyDate || ngModel\" " +
+              "ng-model=\"time\" " +
+              "ng-change=\"time_change()\" " +
+              "style=\"display:inline-block\">\n" +
             "<timepicker " + [
               ["hourStep"],
               ["minuteStep"],
@@ -117,6 +122,9 @@ angular.module('ui.bootstrap.datetimepicker',
         },
         controller: ['$scope',
           function($scope) {
+            // Default value is true
+            $scope.showTimeForEmptyDate = $scope.showTimeForEmptyDate == null || $scope.showTimeForEmptyDate ;
+
             $scope.time_change = function() {
               if ($scope.ngModel && $scope.time) {
                 $scope.ngModel.setHours($scope.time.getHours(), $scope.time.getMinutes());


### PR DESCRIPTION
Not showing the time inputs when the date is empty helps:
- making it clear that the datetimepicker value is empty
- reducing the number of inputs when not needed