### PR TITLE
add additional type check for model

### DIFF
--- a/datetimepicker.js
+++ b/datetimepicker.js
@@ -137,7 +137,7 @@ angular.module('ui.bootstrap.datetimepicker',
             $scope.time_change = function() {
               if ($scope.ngModel && $scope.time) {
                 // convert from ISO format to Date
-                if (typeof $scope.ngModel == "string") $scope.ngModel = new Date($scope.ngModel);
+                if (typeof $scope.ngModel === "string" || typeof $scope.ngModel == "number") $scope.ngModel = new Date($scope.ngModel);
                 $scope.ngModel.setHours($scope.time.getHours(), $scope.time.getMinutes(), 0, 0);
               }
             };


### PR DESCRIPTION
if the model is typeof number (unix timestamp) the bug https://github.com/zhaber/datetimepicker/issues/13 would also occur.
this check prevents said error.